### PR TITLE
fix body.properties.Description too long

### DIFF
--- a/libs/notion.ts
+++ b/libs/notion.ts
@@ -74,6 +74,9 @@ export class Notion {
     }
 
     async insertPage(repo: Repo) {
+        if (repo.description && repo.description.length >= 2000) {
+            repo.description = repo.description.substr(0, 120) + '...'
+        }
         const data = await this.notion.pages.create({
             parent: {
                 database_id: databaseId,


### PR DESCRIPTION
If the description was too long the following error would occur, I fixed it.

```
APIResponseError: body failed validation: body.properties.Description.rich_text[0].text.content.length should be ≤ `2000`, instead was `5835`.
    at Object.buildRequestError (/home/runner/work/github-notion-star/github-notion-star/node_modules/@notionhq/client/src/errors.ts:240:12)
    at Client.request (/home/runner/work/github-notion-star/github-notion-star/node_modules/@notionhq/client/src/Client.ts:157:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Notion.insertPage (/home/runner/work/github-notion-star/github-notion-star/libs/notion.ts:77:22)
    at fullSync (/home/runner/work/github-notion-star/github-notion-star/main.ts:10:13)
Error: Process completed with exit code 1.
```