### PR TITLE
fix: upload-artifact v2 was deprecated

### DIFF
--- a/.github/workflows/partial-sync.yml
+++ b/.github/workflows/partial-sync.yml
@@ -39,7 +39,7 @@ jobs:
           REPO_TOPICS_LIMIT: 50
         run: npm start
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: notion-sync-storage
           path: .cache


### PR DESCRIPTION
Due to upload-artifact v2 was deprecated, the GitHub actions got failed.